### PR TITLE
fix pip git install URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Collection of tools for condensed matter physics written in Python.
 
 Install via `pip` from github:
 ```commandline
-pip install git+git://github.com/dylanljones/cmpy.git@VERSION
+pip install git+https://github.com/dylanljones/cmpy.git@VERSION
 ```
 
 or download/clone the package, navigate to the root directory and install via


### PR DESCRIPTION
otherwise: "The unauthenticated git protocol on port 9418 is no longer supported."

Ref: https://github.blog/2021-09-01-improving-git-protocol-security-github/